### PR TITLE
Use hash of URL as default key

### DIFF
--- a/demo/index.php
+++ b/demo/index.php
@@ -10,7 +10,6 @@
 
     $cacheInstance = new Cache(array(
         'url'    => $requestUrl,
-        'key'    => 'ip_lookup',
         'expire' => 'hourly'
     ));
 

--- a/src/Cache.class.php
+++ b/src/Cache.class.php
@@ -17,8 +17,8 @@ class Cache
     private $currentTime;
 
     // Cache
-    private $url          = '';
-    private $key          = 'default';
+    private $url          = null;
+    private $key          = null;
     private $expire       = 'nightly';
     private $offset       = 0;
     private $mustMatch    = null;
@@ -56,6 +56,11 @@ class Cache
             foreach($args as $key => $val) {
                 $this->{$key} = $val;
             }
+        }
+
+        // Set default key
+        if (!$this->key) {
+            $this->key = md5($this->url);
         }
 
         // Congruency points


### PR DESCRIPTION
This saves the effort of defining a key. It's simple enough to create one from the `url`.