### PR TITLE
Revise expirations in seconds

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,10 @@ The identifier of this specific cache instance (i.e., `instagram_feed` or `weath
 
 ### expire _(integer or string)_
 
-The interval of time after which the cache will expire. Accepts either an integer (number of seconds) or a friendly keyword from the list below:
+The interval of time after which the cache will expire. Accepts either an integer (a number of seconds), or a friendly keyword from the list below:
 
 Value              | Expiration
 :----------        | :-----------
-second             | Every second
 minute             | Every minute
 hourly             | Every hour
 workday            | Every eight hours

--- a/src/Cache.php
+++ b/src/Cache.php
@@ -5,9 +5,10 @@
  *
  * Caches data while intelligently managing a history of previous states.
  *
- * @author  Chris Ullyott
- * @link https://github.com/chrisullyott/wayback-cache
  * @version 3.0
+ * @link https://github.com/chrisullyott/wayback-cache
+ * @author Chris Ullyott
+ * @copyright Chris Ullyott
  */
 
 use Cache\Library\Data\Catalog;

--- a/src/Library/Utility/Time.php
+++ b/src/Library/Utility/Time.php
@@ -19,10 +19,7 @@ class Time
     {
         switch ($expire) {
             case is_numeric($expire):
-                $time = strtotime("+{$expire} second", strtotime(date('Y-m-d H:i:s')));
-                break;
-            case 'second':
-                $time = strtotime('+1 second', strtotime(date('Y-m-d H:i:s')));
+                $time = time() + $expire;
                 break;
             case 'minute':
                 $time = strtotime('+1 minute', strtotime(date('Y-m-d H:i:00')));


### PR DESCRIPTION
Removes the `second` expiration keyword, since you can now easily use `1` or any number of seconds when setting an expiration interval.