### PR TITLE
Fix quick instantiation

### DIFF
--- a/src/Cache.php
+++ b/src/Cache.php
@@ -127,9 +127,14 @@ class Cache
         // Set properties.
         if (is_array($a[0])) {
             $this->setProperties($a[0]);
-        } elseif (isset($a[0]) && isset($a[1])) {
-            $this->key = $a[0];
-            $this->expire = $a[1];
+        } else {
+            if (isset($a[0])) {
+                $this->key = $a[0];
+            }
+
+            if (isset($a[1])) {
+                $this->expire = $a[1];
+            }
         }
 
         // Initialize if invalid.


### PR DESCRIPTION
A cache couldn't be instantiated here without the 'expire' param.